### PR TITLE
Update relprior.c: Make error message more descriptive

### DIFF
--- a/relprior.c
+++ b/relprior.c
@@ -567,7 +567,8 @@ init_manchors (bool_t quietmode, const char *fpins_name, struct RATINGS *rat /*@
 		fclose(fpins);
 	}
 	else {
-		file_success = FALSE;
+		fprintf (stderr, "Errors in file \"%s\" (can not open the file)\n",fpins_name);
+		exit(EXIT_FAILURE);
 	}
 
 	if (!file_success) {


### PR DESCRIPTION
In case if `-m` file (for example, `anchors.csv`) can not be opened the program currently just states:
```
Errors in file "anchors.csv"
```
It's a little bit misleading because there can be no errors in `anchors.csv` file, but the file itself can be absent or non-readable because for example of wrong permissions.

This commit makes the message more to the point:
```
Errors in file "anchors.csv" (can not open the file)
```